### PR TITLE
Use asarUnpack to unpack mpris-service module

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,10 @@
     "dist": "build"
   },
   "build": {
-    "asar": {
-      "unpack": "**/D-Bus/**/*"
-    },
+    "asarUnpack": [
+      "windows/spotify/D-Bus",
+      "node_modules/mpris-service"
+    ],
     "files": ["**/*", "!spotifywebplayer", "!*.md", "!*.sh"],
     "extraResources": "plugins/libpepflashplayer-${arch}.so",
     "linux": {


### PR DESCRIPTION
This option will be available in the next `8.3.0` (will be published in 10 minutes) electron-builder. 