### PR TITLE
create a zip build for linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
       "depends": ["libappindicator1", "libindicator7", "libnotify4", "notify-osd", "wget", "unzip", "tar"],
       "target": [
         "AppImage",
-        "deb"
+        "deb",
+        "zip"
       ]
     }
   },


### PR DESCRIPTION
It's better to provide a zip build or a .tar.gz for linux distro that are not based on Debian. I needed that in order to package your application on ArchLinux. 
Thank you!